### PR TITLE
remove illuminate/contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "filament/filament": "^3.0",
         "filament/forms": "^3.0",
         "filament/tables": "^3.0",
-        "spatie/laravel-package-tools": "^1.15.0",
-        "illuminate/contracts": "^10.0"
+        "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",


### PR DESCRIPTION
so this was the secret why @awcodes packages don't need any changes to make it works with L11 😂

I think it is not needed since its already will be installed as a dependencies for `filament/support`, which is required by all filament packages already.

one less thing to worry about when upgrading to a new laravel version