### PR TITLE
Add `filamentphp` as default Composer keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "keywords": [
         ":vendor_name",
         "laravel",
+        "filamentphp",
         ":package_slug"
     ],
     "homepage": "https://github.com/:vendor_slug/:package_slug",


### PR DESCRIPTION
This way, we can easily filter packages at packagist.org specific for Filament PHP.