### PR TITLE
Update file search command to correctly handle plugin names containin…

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -342,7 +342,7 @@ function determineSeparator(string $path): string
 
 function replaceForWindows(): array
 {
-    return preg_split('/\\r\\n|\\r|\\n/', run('dir /S /B * | findstr /v /i .git\ | findstr /v /i vendor | findstr /v /i ' . basename(__FILE__) . ' | findstr /r /i /M /F:/ ":author :vendor :package VendorName skeleton migration_table_name vendor_name vendor_slug author@domain.com"'));
+    return preg_split('/\\r\\n|\\r|\\n/', run('dir /S /B * | findstr /v /i .git\ | findstr /v /i \\vendor\\ | findstr /v /i ' . basename(__FILE__) . ' | findstr /r /i /M /F:/ ":author :vendor :package VendorName skeleton migration_table_name vendor_name vendor_slug author@domain.com"'));
 }
 
 function replaceForAllOtherOSes(): array


### PR DESCRIPTION
The file search command excludes all paths that contain vendor, but if the plugin name contains vendor in it i.e.: "multivendor" it filters all the valid paths out also. So specifically filtering out only the paths containing '\vendor' solves the issue.