### PR TITLE
Remove unnecessary includes from phpstan.neon.dist

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,4 @@
 includes:
-    - vendor/larastan/larastan/extension.neon
-    - vendor/nesbot/carbon/extension.neon
     - phpstan-baseline.neon
 
 parameters:


### PR DESCRIPTION
Remove unnecessary includes from phpstan.neon.dist. These dependencies are loaded by phpstan/extension-installer plugin. These includes conflicted with the phpstan/extension-installer plugin.